### PR TITLE
[libtool]: Add inspec tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
-# base-plan-skeleton
-Template for all new Chef Base Plans to simplify creation of repositories.
+# libtool
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_apis/build/status/chef-base-plans.libtool?branchName=master)](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_build/latest?definitionId=69&branchName=master)
+
 # libtool
 
 ## Maintainers

--- a/attributes.yml
+++ b/attributes.yml
@@ -1,0 +1,1 @@
+command_relative_path: 'bin/libtool'

--- a/controls/libtool_exists.rb
+++ b/controls/libtool_exists.rb
@@ -1,0 +1,24 @@
+title 'Tests to confirm libtool exists'
+
+plan_origin = ENV['HAB_ORIGIN']
+plan_name = input('plan_name', value: 'libtool')
+
+control 'core-plans-libtool-exists' do
+  impact 1.0
+  title 'Ensure libtool exists'
+  desc '
+  Verify libtool by ensuring bin/libtool exists'
+  
+  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+  describe plan_installation_directory do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stderr') { should be_empty }
+  end
+
+  command_relative_path = input('command_relative_path', value: 'bin/libtool')
+  command_full_path = File.join(plan_installation_directory.stdout.strip, "#{command_relative_path}")
+  describe file(command_full_path) do
+    it { should exist }
+  end
+end

--- a/controls/libtool_works.rb
+++ b/controls/libtool_works.rb
@@ -1,0 +1,95 @@
+title 'Tests to confirm libtool works as expected'
+
+plan_origin = ENV['HAB_ORIGIN']
+plan_name = input('plan_name', value: 'libtool')
+
+control 'core-plans-libtool-works' do
+  impact 1.0
+  title 'Ensure libtool works as expected'
+  desc '
+  Verify libtool by ensuring 
+  (1) its installation directory exists and 
+  (2) that it returns the expected version.
+  (3) that the binaries and libraries it references in libtool --config
+      all exist.  NOTE: several binaries and directores currently do not exist
+      and an issue has been raised to resolve as defined below.  When the issue
+      is resolved these test should no longer be skipped
+  '
+  
+  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+  describe plan_installation_directory do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stderr') { should be_empty }
+  end
+  
+  command_relative_path = input('command_relative_path', value: 'bin/libtool')
+  command_full_path = File.join(plan_installation_directory.stdout.strip, "#{command_relative_path}")
+  plan_pkg_version = plan_installation_directory.stdout.split("/")[5]
+  describe command("#{command_full_path} --version") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stdout') { should match /libtool \(GNU libtool\) #{plan_pkg_version}/ }
+    its('stderr') { should be_empty }
+  end
+
+  libtool_config_output = command("#{command_full_path} --config")
+  grep_binary_regex = /GREP="(?<grep_binary_path>.+)"/
+  sed_binary_regex = /SED="(?<sed_binary_path>.+)"/
+  nm_binary_regex = /NM="(?<nm_binary_path>.+)"/
+  ld_binary_regex = /LD="(?<ld_binary_path>.+)"/
+  ltcflags_regex = /LTCFLAGS="(?<ltcflags_include_directories>.+)"/
+  dd_binary_regex = /lt_truncate_bin="(?<dd_binary_fullpath>.+)bs.*"/
+  describe libtool_config_output do
+    its('exit_status') { should eq 0 }
+    its('stderr') { should be_empty }
+    its('stdout') { should_not be_empty }
+    its('stdout') { should match /#{grep_binary_regex}/ }
+    its('stdout') { should match /#{sed_binary_regex}/ }
+    its('stdout') { should match /#{nm_binary_regex}/ }
+    its('stdout') { should match /#{ld_binary_regex}/ }
+    its('stdout') { should match /#{ltcflags_regex}/ }
+    its('stdout') { should match /#{dd_binary_regex}/ }
+  end
+
+  grep_binary_fullpath = (libtool_config_output.stdout.match /#{grep_binary_regex}/)[1]
+  describe file(grep_binary_fullpath) do
+    it { should exist }
+  end
+
+  sed_binary_fullpath = (libtool_config_output.stdout.match /#{sed_binary_regex}/)[1]
+  describe file(sed_binary_fullpath) do
+    it { should exist }
+  end
+
+  ld_binary_regex = /LD="(?<ld_binary_path>.+)"/
+  ld_binary_fullpath = (libtool_config_output.stdout.match /#{ld_binary_regex}/)[1]
+  describe file(ld_binary_fullpath) do
+    it { should exist }
+  end
+
+  ##################################################################################
+  ######   THE FOLLOWING TESTS ARE FAILING SO SKIPPED UNTIL ISSUE RESOLVED    ######
+  ######        https://github.com/chef-base-plans/libtool/issues/1           ######
+  ##################################################################################
+  nm_binary_fullpath = (libtool_config_output.stdout.match /#{nm_binary_regex}/)[1]
+  describe file(nm_binary_fullpath) do
+    xit { should exist }
+  end
+
+  dd_binary_regex = /lt_truncate_bin="(?<dd_binary_fullpath>.+)bs.*"/
+  dd_binary_fullpath = (libtool_config_output.stdout.match /#{dd_binary_regex}/)[1]
+  describe file(dd_binary_fullpath) do
+    xit { should exist }
+  end
+  
+  ltcflags_regex = /LTCFLAGS="(?<ltcflags_include_directories>.+)"/
+  ltcflags_directories = (libtool_config_output.stdout.match /#{ltcflags_regex}/)[1]
+  ltcflags_directories.split(" ").each { |item|
+    item.gsub!("-I","")
+    describe file(item) do
+      xit { should exist }
+    end
+  }
+
+end

--- a/inspec.yml
+++ b/inspec.yml
@@ -1,9 +1,9 @@
-name: {{plan_name}}
-title: Habitat Core Plan {{plan_name}}
-maintainer: humans@habitat.sh
-summary: InSpec controls for testing Habitat Core Plan {{plan_name}}
-copyright: humans@habitat.sh
-copyright_email: humans@habitat.sh
+name: libtool
+title: Habitat Core Plan libtool
+maintainer: "The Habitat Maintainers <humans@habitat.sh>"
+summary: InSpec controls for testing Habitat Core Plan libtool
+copyright: 2019, Chef Software, Inc.
+copyright_email: legal@chef.io
 version: 0.1.0
 license: Apache-2.0
 inspec_version: '>= 3.0.25'

--- a/plan.sh
+++ b/plan.sh
@@ -1,0 +1,64 @@
+pkg_name=libtool
+pkg_origin=core
+pkg_version=2.4.6
+pkg_license=('GPL-2.0-or-later')
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_description="\
+GNU libtool is a generic library support script. Libtool hides the complexity \
+of using shared libraries behind a consistent, portable interface.\
+"
+pkg_upstream_url="http://www.gnu.org/software/libtool"
+pkg_source="http://ftp.gnu.org/gnu/${pkg_name}/${pkg_name}-${pkg_version}.tar.gz"
+pkg_shasum="e3bd4d5d3d025a36c21dd6af7ea818a2afcd4dfc1ea5a17b39d7854bcd0c06e3"
+pkg_filename="${pkg_name}-${pkg_version}.tar.gz"
+pkg_deps=(
+  core/glibc
+  core/coreutils
+  core/sed
+  core/grep
+  core/binutils
+)
+pkg_build_deps=(
+  core/diffutils
+  core/patch
+  core/make
+  core/gcc
+  core/m4
+)
+pkg_bin_dirs=(bin)
+pkg_include_dirs=(include)
+pkg_lib_dirs=(lib)
+
+do_prepare() {
+  do_default_prepare
+
+  # Drop the dependency on `help2man` by skipping the generation of a man page
+  sed \
+    -e "/^dist_man1_MANS =/ s,^.*$,dist_man1_MANS = $(libtoolize_1),g" \
+    -i Makefile.in
+}
+
+do_build() {
+  # * `lt_cv_sys_dlsearch_path` Makes the default library search path empty,
+  # rather than `"/lib /usr/lib"`
+  ./configure \
+    --prefix="$pkg_prefix" \
+    lt_cv_sys_lib_dlsearch_path_spec="" \
+    lt_cv_sys_lib_search_path_spec=""
+  make
+}
+
+
+# ----------------------------------------------------------------------------
+# **NOTICE:** What follows are implementation details required for building a
+# first-pass, "stage1" toolchain and environment. It is only used when running
+# in a "stage1" Studio and can be safely ignored by almost everyone. Having
+# said that, it performs a vital bootstrapping process and cannot be removed or
+# significantly altered. Thank you!
+# ----------------------------------------------------------------------------
+if [[ "$STUDIO_TYPE" = "stage1" ]]; then
+  pkg_build_deps=(
+    core/gcc
+    core/m4
+  )
+fi

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -1,0 +1,18 @@
+@test "libtool paths are set correctly" {
+  deps_path="$(< /hab/pkgs/$TEST_PKG_IDENT/DEPS)"
+  grep_ident="$(grep -E "^core/grep/" <<< "$deps_path" )"
+  sed_ident="$(grep -E "^core/sed/" <<< "$deps_path" )"
+
+  run hab pkg exec $TEST_PKG_IDENT libtool --config
+  grep -qE "^GREP=\"/hab/pkgs/$grep_ident/bin/grep\"" <<< "${output[@]}"
+  grep -qE "^SED=\"/hab/pkgs/$sed_ident/bin/sed\"" <<< "${output[@]}"
+}
+
+@test "library search paths are empty" {
+  run hab pkg exec $TEST_PKG_IDENT libtool --config
+
+  grep -q 'compiler_lib_search_dirs=""' <<< "${output[@]}"
+  grep -q 'compiler_lib_search_path=""' <<< "${output[@]}"
+  grep -q 'sys_lib_search_path_spec=""' <<< "${output[@]}"
+  grep -q 'sys_lib_dlsearch_path_spec=""' <<< "${output[@]}"
+}

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+bats "$(dirname "${0}")/test.bats" --tap


### PR DESCRIPTION
NOTE:
* Several failing tests have been added here but skipped intentionally because of an outstanding issue raised here #1 and also against the core-plans repository https://github.com/habitat-sh/core-plans/issues/3395.  When the issue(s) has been resolved, then these tests should be enabled.