### PR TITLE
[libtool]: Update documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-results
+results/
+inspec.lock

--- a/README.md
+++ b/README.md
@@ -1,15 +1,77 @@
-[![Build Status](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_apis/build/status/chef-base-plans.libtool?branchName=master)](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_build/latest?definitionId=69&branchName=master)
+[![Build Status](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_apis/build/status/chef-base-plans.libtool?branchName=master)](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_build/latest?definitionId=127&branchName=master)
 
 # libtool
 
+GNU libtool is a generic library support script. Libtool hides the complexity of using shared libraries behind a consistent, portable interface.  See [documentation](https://www.gnu.org/software/libtool/)
+
 ## Maintainers
 
-* The Habitat Maintainers: <humans@habitat.sh>
+* The Core Planners: <chef-core-planners@chef.io>
 
 ## Type of Package
 
 Binary package
 
-## Usage
+### Use as Dependency
 
-*TODO: Add instructions for usage*
+Binary packages can be set as runtime or build time dependencies. See [Defining your dependencies](https://www.habitat.sh/docs/developing-packages/developing-packages/#sts=Define%20Your%20Dependencies) for more information.
+
+To add core/libtool as a dependency, you can add one of the following to your plan file.
+
+##### Buildtime Dependency
+
+> pkg_build_deps=(core/libtool)
+
+##### Runtime dependency
+
+> pkg_deps=(core/libtool)
+
+### Use as Tool
+
+#### Installation
+
+To install this plan, you should run the following commands to first install, and then link the binaries this plan creates.
+
+``hab pkg install core/libtool --binlink``
+
+will add the following binaries to the PATH:
+
+* /bin/libtool
+* /bin/libtoolize
+
+For example:
+
+```bash
+$ hab pkg install core/libtool --binlink
+» Installing core/libtool
+☁ Determining latest version of core/libtool in the 'stable' channel
+→ Found newer installed version (core/libtool/2.4.6/20200612110137) than remote version (core/libtool/2.4.6/20200305233901)
+→ Using core/libtool/2.4.6/20200612110137
+★ Install of core/libtool/2.4.6/20200612110137 complete with 0 new packages installed.
+» Binlinking libtoolize from core/libtool/2.4.6/20200612110137 into /bin
+★ Binlinked libtoolize from core/libtool/2.4.6/20200612110137 to /bin/libtoolize
+» Binlinking libtool from core/libtool/2.4.6/20200612110137 into /bin
+★ Binlinked libtool from core/libtool/2.4.6/20200612110137 to /bin/libtool
+```
+
+#### Using an example binary
+
+You can now use the binary as normal.  For example:
+
+``/bin/libtool --help`` or ``libtool --help``
+
+```bash
+$ libtool --help
+Usage: /bin/libtool [OPTION]... [MODE-ARG]...
+
+Provide generalized library-building support services.
+
+Options:
+       --config             show all configuration variables
+       --debug              enable verbose shell tracing
+   -n, --dry-run            display commands without modifying any files
+       --features           display basic configuration information and exit
+       --mode=MODE          use operation mode MODE
+...
+...
+```

--- a/attributes.yml
+++ b/attributes.yml
@@ -1,1 +1,2 @@
-command_relative_path: 'bin/libtool'
+plan_name: 'libtool'
+

--- a/controls/libtool_exists.rb
+++ b/controls/libtool_exists.rb
@@ -3,11 +3,14 @@ title 'Tests to confirm libtool exists'
 plan_origin = ENV['HAB_ORIGIN']
 plan_name = input('plan_name', value: 'libtool')
 
+
 control 'core-plans-libtool-exists' do
   impact 1.0
   title 'Ensure libtool exists'
   desc '
-  Verify libtool by ensuring bin/libtool exists'
+  Verify libtool by ensuring libtool and libtoolize
+  (1) exist and
+  (2) are executable'
   
   plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
   describe plan_installation_directory do
@@ -16,9 +19,14 @@ control 'core-plans-libtool-exists' do
     its('stderr') { should be_empty }
   end
 
-  command_relative_path = input('command_relative_path', value: 'bin/libtool')
-  command_full_path = File.join(plan_installation_directory.stdout.strip, "#{command_relative_path}")
-  describe file(command_full_path) do
-    it { should exist }
+  [
+    "libtool",
+    "libtoolize"
+  ].each do |binary_name|
+    command_full_path = File.join(plan_installation_directory.stdout.strip, "bin", binary_name)
+    describe file(command_full_path) do
+      it { should exist }
+      it { should be_executable }
+    end
   end
 end

--- a/controls/libtool_works.rb
+++ b/controls/libtool_works.rb
@@ -7,15 +7,16 @@ control 'core-plans-libtool-works' do
   impact 1.0
   title 'Ensure libtool works as expected'
   desc '
-  Verify libtool by ensuring 
-  (1) its installation directory exists and 
-  (2) that it returns the expected version.
-  (3) that the binaries and libraries it references in libtool --config
-      all exist.  NOTE: several binaries and directores currently do not exist
-      and an issue has been raised to resolve as defined below.  When the issue
-      is resolved these test should no longer be skipped
+  Verify libtool by ensuring that
+  (1) installation directory should exist
+  (2) binaries should return correct version
+  (3) libtool --config should return non-empty text
+  (4) libtool --config should contain all the above file and directory patterns
+  (5a) all file patterns should exist on the system
+  (5b) all directories should exist on the system
   '
   
+  # (1) installation directory should exist
   plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
   describe plan_installation_directory do
     its('exit_status') { should eq 0 }
@@ -23,73 +24,62 @@ control 'core-plans-libtool-works' do
     its('stderr') { should be_empty }
   end
   
-  command_relative_path = input('command_relative_path', value: 'bin/libtool')
-  command_full_path = File.join(plan_installation_directory.stdout.strip, "#{command_relative_path}")
+  # (2) binaries should return correct version
   plan_pkg_version = plan_installation_directory.stdout.split("/")[5]
-  describe command("#{command_full_path} --version") do
-    its('exit_status') { should eq 0 }
-    its('stdout') { should_not be_empty }
-    its('stdout') { should match /libtool \(GNU libtool\) #{plan_pkg_version}/ }
-    its('stderr') { should be_empty }
+  [
+    "libtool",
+    "libtoolize"
+  ].each do |binary_name|
+    command_full_path = File.join(plan_installation_directory.stdout.strip, "bin", binary_name)
+    describe command("#{command_full_path} --version") do
+      its('exit_status') { should eq 0 }
+      its('stdout') { should_not be_empty }
+      its('stdout') { should match /#{binary_name} \(GNU libtool\) #{plan_pkg_version}/ }
+      its('stderr') { should be_empty }
+    end
   end
 
-  libtool_config_output = command("#{command_full_path} --config")
-  grep_binary_regex = /GREP="(?<grep_binary_path>.+)"/
-  sed_binary_regex = /SED="(?<sed_binary_path>.+)"/
-  nm_binary_regex = /NM="(?<nm_binary_path>.+)"/
-  ld_binary_regex = /LD="(?<ld_binary_path>.+)"/
-  ltcflags_regex = /LTCFLAGS="(?<ltcflags_include_directories>.+)"/
-  dd_binary_regex = /lt_truncate_bin="(?<dd_binary_fullpath>.+)bs.*"/
+  # (3) libtool --config should return non-empty text
+  libtool_full_path = File.join(plan_installation_directory.stdout.strip, "bin", "libtool")
+  libtool_config_output = command("#{libtool_full_path} --config")
   describe libtool_config_output do
     its('exit_status') { should eq 0 }
     its('stderr') { should be_empty }
     its('stdout') { should_not be_empty }
-    its('stdout') { should match /#{grep_binary_regex}/ }
-    its('stdout') { should match /#{sed_binary_regex}/ }
-    its('stdout') { should match /#{nm_binary_regex}/ }
-    its('stdout') { should match /#{ld_binary_regex}/ }
-    its('stdout') { should match /#{ltcflags_regex}/ }
-    its('stdout') { should match /#{dd_binary_regex}/ }
   end
 
-  grep_binary_fullpath = (libtool_config_output.stdout.match /#{grep_binary_regex}/)[1]
-  describe file(grep_binary_fullpath) do
-    it { should exist }
+  # initialize file and directory patterns
+  files = [
+    /^GREP="(?<grep_binary_path>.+)"/,
+    /^SED="(?<sed_binary_path>.+)"/,
+    /^LD="(?<ld_binary_path>.+)"/,
+    /NM="(?<nm_binary_path>[^\s]+).*"/,
+    /lt_truncate_bin="(?<dd_binary_fullpath>[^\s]+)\s+bs.*"/
+  ]
+  directories = /LTCFLAGS="(?<ltcflags_include_directories>.+)"/
+
+  # (4) libtool --config should contain all the above file and directory patterns
+  all_patterns = files + [directories]
+  all_patterns.each do |pattern|
+    describe libtool_config_output do
+      its('stdout') { should match pattern }
+    end
   end
 
-  sed_binary_fullpath = (libtool_config_output.stdout.match /#{sed_binary_regex}/)[1]
-  describe file(sed_binary_fullpath) do
-    it { should exist }
+  # (5a) all file patterns should exist on the system
+  files.each do |pattern|
+    binary_fullpath = (libtool_config_output.stdout.match pattern)[1]
+    describe file(binary_fullpath) do
+      it { should exist }
+    end
   end
 
-  ld_binary_regex = /LD="(?<ld_binary_path>.+)"/
-  ld_binary_fullpath = (libtool_config_output.stdout.match /#{ld_binary_regex}/)[1]
-  describe file(ld_binary_fullpath) do
-    it { should exist }
-  end
-
-  ##################################################################################
-  ######   THE FOLLOWING TESTS ARE FAILING SO SKIPPED UNTIL ISSUE RESOLVED    ######
-  ######        https://github.com/chef-base-plans/libtool/issues/1           ######
-  ##################################################################################
-  nm_binary_fullpath = (libtool_config_output.stdout.match /#{nm_binary_regex}/)[1]
-  describe file(nm_binary_fullpath) do
-    xit { should exist }
-  end
-
-  dd_binary_regex = /lt_truncate_bin="(?<dd_binary_fullpath>.+)bs.*"/
-  dd_binary_fullpath = (libtool_config_output.stdout.match /#{dd_binary_regex}/)[1]
-  describe file(dd_binary_fullpath) do
-    xit { should exist }
-  end
-  
-  ltcflags_regex = /LTCFLAGS="(?<ltcflags_include_directories>.+)"/
-  ltcflags_directories = (libtool_config_output.stdout.match /#{ltcflags_regex}/)[1]
-  ltcflags_directories.split(" ").each { |item|
+  # (5b) all directories should exist on the system
+  ltcflags_directories = (libtool_config_output.stdout.match directories)[1]
+  ltcflags_directories.split(" ").each do|item|
     item.gsub!("-I","")
     describe file(item) do
-      xit { should exist }
+      it { should exist }
     end
-  }
-
+  end
 end

--- a/controls/libtool_works.rb
+++ b/controls/libtool_works.rb
@@ -13,8 +13,7 @@ control 'core-plans-libtool-works' do
   (3) libtool --config should return non-empty text
   (4) libtool --config should contain all the above file and directory patterns
   (5a) all file patterns should exist on the system
-  (5b) all directories should exist on the system
-  '
+  (5b) all directories should exist on the system'
   
   # (1) installation directory should exist
   plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")

--- a/inspec.yml
+++ b/inspec.yml
@@ -1,9 +1,7 @@
 name: libtool
 title: Habitat Core Plan libtool
-maintainer: "The Habitat Maintainers <humans@habitat.sh>"
+maintainer: "The Core Planners <chef-core-planners@chef.io>"
 summary: InSpec controls for testing Habitat Core Plan libtool
-copyright: 2019, Chef Software, Inc.
-copyright_email: legal@chef.io
 version: 0.1.0
 license: Apache-2.0
-inspec_version: '>= 3.0.25'
+inspec_version: '>= 4.18.108'

--- a/plan.sh
+++ b/plan.sh
@@ -11,18 +11,23 @@ pkg_upstream_url="http://www.gnu.org/software/libtool"
 pkg_source="http://ftp.gnu.org/gnu/${pkg_name}/${pkg_name}-${pkg_version}.tar.gz"
 pkg_shasum="e3bd4d5d3d025a36c21dd6af7ea818a2afcd4dfc1ea5a17b39d7854bcd0c06e3"
 pkg_filename="${pkg_name}-${pkg_version}.tar.gz"
+# NOTE: including some obvious buildtime dependencies like
+# core/make and core/gcc because they are required by the runtime libtool.
+# Specifically libtool --config returns a configuration list of files and directories
+# that is defined at buildtime and then also used at runtime.  The buildtime location of
+# gcc, for example, is expected to also be available at runtime.
 pkg_deps=(
   core/glibc
   core/coreutils
   core/sed
   core/grep
   core/binutils
+  core/make
+  core/gcc
 )
 pkg_build_deps=(
   core/diffutils
   core/patch
-  core/make
-  core/gcc
   core/m4
 )
 pkg_bin_dirs=(bin)


### PR DESCRIPTION
Also:

* Fixed the broken tests--though the solution is still an outstanding issue #1:  The runtime environment may not include necessary dependencies because the libtool configures its file and directory paths at buildtime.
* Simplified tests into a few arrays over inspec verifications.